### PR TITLE
[release-0.2] Accept IPv6 address as CN names

### DIFF
--- a/factory/gen.go
+++ b/factory/gen.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	cnRegexp = regexp.MustCompile("^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$")
+	cnRegexp = regexp.MustCompile("^([A-Za-z0-9:][-A-Za-z0-9_.:]*)?[A-Za-z0-9:]$")
 )
 
 type TLS struct {


### PR DESCRIPTION
Expand the cnRegexp to also accept ipv6 addresses such as:
  * ::1
  * 2a00:1450:400e:80e::
  * 2a00:1450:400e:80e::200e

Related to: #37

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>
(cherry picked from commit dc7452dbb8d0c805672eac2a71d8e0627a45c779)