### PR TITLE
Fix net.Conn type assertion

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -299,7 +299,7 @@ func (l *listener) getCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate,
 		}
 	}
 
-	return l.loadCert(newConn.(*closeWrapper))
+	return l.loadCert(newConn)
 }
 
 func (l *listener) updateCert(cn ...string) error {
@@ -341,7 +341,7 @@ func (l *listener) updateCert(cn ...string) error {
 	return nil
 }
 
-func (l *listener) loadCert(currentConn *closeWrapper) (*tls.Certificate, error) {
+func (l *listener) loadCert(currentConn net.Conn) (*tls.Certificate, error) {
 	l.RLock()
 	defer l.RUnlock()
 
@@ -381,7 +381,7 @@ func (l *listener) loadCert(currentConn *closeWrapper) (*tls.Certificate, error)
 			}
 			_ = conn.close()
 		}
-		l.conns[currentConn.id].ready = true
+		l.conns[currentConn.(*closeWrapper).id].ready = true
 		l.connLock.Unlock()
 	}
 


### PR DESCRIPTION
Don't assert that all connections are wrapped, as they won't be if
the CloseConnOnCertChange setting is false. Only run the assertion
within a conditional for wrapped connections, where it is safe. This
prevents a panic from happening when CloseConnOnCertChange is not used.

Fixes an issue found by the rancher/rancher provisioning tests.