### PR TITLE
Allow for default expiration days to be loaded from env

### DIFF
--- a/factory/cert_utils.go
+++ b/factory/cert_utils.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"math/big"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,7 +19,8 @@ import (
 )
 
 const (
-	CertificateBlockType = "CERTIFICATE"
+	CertificateBlockType               = "CERTIFICATE"
+	defaultNewSignedCertExpirationDays = 365
 )
 
 func NewSelfSignedCACert(key crypto.Signer, cn string, org ...string) (*x509.Certificate, error) {
@@ -82,12 +85,22 @@ func NewSignedCert(signer crypto.Signer, caCert *x509.Certificate, caKey crypto.
 		return nil, err
 	}
 
+	expirationDays := defaultNewSignedCertExpirationDays
+	envExpirationDays := os.Getenv("CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS")
+	if envExpirationDays != "" {
+		if envExpirationDaysInt, err := strconv.Atoi(envExpirationDays); err != nil {
+			logrus.Infof("[NewSignedCert] expiration days from ENV (%s) could not be converted to int (falling back to default value: %d)", envExpirationDays, defaultExpirationDays)
+		} else {
+			expirationDays = envExpirationDaysInt
+		}
+	}
+
 	parent := x509.Certificate{
 		DNSNames:     domains,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		IPAddresses:  ips,
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		NotAfter:     time.Now().Add(time.Hour * 24 * 365).UTC(),
+		NotAfter:     time.Now().Add(time.Hour * 24 * time.Duration(expirationDays)).UTC(),
 		NotBefore:    caCert.NotBefore,
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{


### PR DESCRIPTION
This PR enables the consumer of dynamiclistener's cert generation to specify the number of days until expiration via ENV VAR. By default, not supplying the ENV VAR will result in the _same_ behavior as before. The ENV VAR is optional and specifying will override the default. If any issues occur, we will fallback to the default value.

Partially resolves: https://github.com/rancher/rancher/issues/35366