### PR TITLE
remove informer check from secrets controller

### DIFF
--- a/storage/kubernetes/controller.go
+++ b/storage/kubernetes/controller.go
@@ -225,8 +225,5 @@ func (s *storage) update(secret *v1.Secret) (err error) {
 func (s *storage) controllerHasSynced() bool {
 	s.RLock()
 	defer s.RUnlock()
-	if s.secrets == nil {
-		return false
-	}
-	return s.secrets.Informer().HasSynced()
+	return s.secrets != nil
 }


### PR DESCRIPTION
This check was added in #57, but appears to be causing problems with the [initial rancher startup](https://github.com/rancher/rancher/pull/36932).