### PR TITLE
Don't merge expired certs over the top of an unexpired cert

### DIFF
--- a/factory/gen.go
+++ b/factory/gen.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rancher/dynamiclistener/cert"
 	"github.com/sirupsen/logrus"
@@ -72,7 +73,8 @@ func collectCNs(secret *v1.Secret) (domains []string, ips []net.IP, err error) {
 
 // Merge combines the SAN lists from the target and additional Secrets, and
 // returns a potentially modified Secret, along with a bool indicating if the
-// returned Secret is not the same as the target Secret.
+// returned Secret is not the same as the target Secret. Secrets with expired
+// certificates will never be returned.
 //
 // If the merge would not add any CNs to the additional Secret, the additional
 // Secret is returned, to allow for certificate rotation/regeneration.
@@ -93,17 +95,17 @@ func (t *TLS) Merge(target, additional *v1.Secret) (*v1.Secret, bool, error) {
 
 	// if the additional secret already has all the CNs, use it in preference to the
 	// current one. This behavior is required to allow for renewal or regeneration.
-	if !NeedsUpdate(0, additional, mergedCNs...) {
+	if !NeedsUpdate(0, additional, mergedCNs...) && !IsExpired(additional) {
 		return additional, true, nil
 	}
 
 	// if the target secret already has all the CNs, continue using it. The additional
 	// cert had only a subset of the current CNs, so nothing needs to be added.
-	if !NeedsUpdate(0, target, mergedCNs...) {
+	if !NeedsUpdate(0, target, mergedCNs...) && !IsExpired(target) {
 		return target, false, nil
 	}
 
-	// neither cert currently has all the necessary CNs; generate a new one.
+	// neither cert currently has all the necessary CNs or is unexpired; generate a new one.
 	return t.generateCert(target, mergedCNs...)
 }
 
@@ -189,6 +191,20 @@ func (t *TLS) generateCert(secret *v1.Secret, cn ...string) (*v1.Secret, bool, e
 	secret.Annotations[fingerprint] = fmt.Sprintf("SHA1=%X", sha1.Sum(newCert.Raw))
 
 	return secret, true, nil
+}
+
+func IsExpired(secret *v1.Secret) bool {
+	certsPem := secret.Data[v1.TLSCertKey]
+	if len(certsPem) == 0 {
+		return false
+	}
+
+	certificates, err := cert.ParseCertsPEM(certsPem)
+	if err != nil || len(certificates) == 0 {
+		return false
+	}
+
+	return time.Now().After(certificates[0].NotAfter)
 }
 
 func (t *TLS) Verify(secret *v1.Secret) error {

--- a/listener.go
+++ b/listener.go
@@ -45,14 +45,18 @@ func NewListener(l net.Listener, storage TLSStorage, caCert *x509.Certificate, c
 	if config.TLSConfig == nil {
 		config.TLSConfig = &tls.Config{}
 	}
+	if config.ExpirationDaysCheck == 0 {
+		config.ExpirationDaysCheck = 90
+	}
 
 	dynamicListener := &listener{
 		factory: &factory.TLS{
-			CACert:       caCert,
-			CAKey:        caKey,
-			CN:           config.CN,
-			Organization: config.Organization,
-			FilterCN:     allowDefaultSANs(config.SANs, config.FilterCN),
+			CACert:              caCert,
+			CAKey:               caKey,
+			CN:                  config.CN,
+			Organization:        config.Organization,
+			FilterCN:            allowDefaultSANs(config.SANs, config.FilterCN),
+			ExpirationDaysCheck: config.ExpirationDaysCheck,
 		},
 		Listener:  l,
 		storage:   &nonNil{storage: storage},
@@ -80,10 +84,6 @@ func NewListener(l net.Listener, storage TLSStorage, caCert *x509.Certificate, c
 		if err := dynamicListener.regenerateCerts(); err != nil {
 			return nil, nil, err
 		}
-	}
-
-	if config.ExpirationDaysCheck == 0 {
-		config.ExpirationDaysCheck = 30
 	}
 
 	tlsListener := tls.NewListener(dynamicListener.WrapExpiration(config.ExpirationDaysCheck), dynamicListener.tlsConfig)


### PR DESCRIPTION
Fixes an issue where an expired Kubernetes secret would replace the renewed locally-cached cert after cluster startup.

Related to https://github.com/k3s-io/k3s/issues/5163

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>