### PR TITLE
Allow multiple (intermediate) CA certs

### DIFF
--- a/factory/ca.go
+++ b/factory/ca.go
@@ -28,6 +28,9 @@ func GenCA() (*x509.Certificate, crypto.Signer, error) {
 // Deprecated: Use LoadOrGenCAChain instead as it supports intermediate CAs
 func LoadOrGenCA() (*x509.Certificate, crypto.Signer, error) {
 	chain, signer, err := LoadOrGenCAChain()
+	if err != nil {
+		return nil, nil, err
+	}
 	return chain[0], signer, err
 }
 
@@ -69,7 +72,10 @@ func loadCA() ([]*x509.Certificate, crypto.Signer, error) {
 
 func LoadCA(caPem, caKey []byte) (*x509.Certificate, crypto.Signer, error) {
 	chain, signer, err := LoadCAChain(caPem, caKey)
-	return chain[0], signer, err
+	if err != nil {
+		return nil, nil, err
+	}
+	return chain[0], signer, nil
 }
 
 func LoadCAChain(caPem, caKey []byte) ([]*x509.Certificate, crypto.Signer, error) {
@@ -93,6 +99,9 @@ func LoadCAChain(caPem, caKey []byte) ([]*x509.Certificate, crypto.Signer, error
 // Deprecated: Use LoadCertsChain instead as it supports intermediate CAs
 func LoadCerts(certFile, keyFile string) (*x509.Certificate, crypto.Signer, error) {
 	chain, signer, err := LoadCertsChain(certFile, keyFile)
+	if err != nil {
+		return nil, nil, err
+	}
 	return chain[0], signer, err
 }
 

--- a/factory/ca.go
+++ b/factory/ca.go
@@ -25,18 +25,25 @@ func GenCA() (*x509.Certificate, crypto.Signer, error) {
 	return caCert, caKey, nil
 }
 
+// Deprecated: Use LoadOrGenCAChain instead as it supports intermediate CAs
 func LoadOrGenCA() (*x509.Certificate, crypto.Signer, error) {
-	cert, key, err := loadCA()
+	chain, signer, err := LoadOrGenCAChain()
+	return chain[0], signer, err
+}
+
+func LoadOrGenCAChain() ([]*x509.Certificate, crypto.Signer, error) {
+	certs, key, err := loadCA()
 	if err == nil {
-		return cert, key, nil
+		return certs, key, nil
 	}
 
-	cert, key, err = GenCA()
+	cert, key, err := GenCA()
 	if err != nil {
 		return nil, nil, err
 	}
+	certs = []*x509.Certificate{cert}
 
-	certBytes, keyBytes, err := Marshal(cert, key)
+	certBytes, keyBytes, err := MarshalChain(key, certs...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,14 +60,19 @@ func LoadOrGenCA() (*x509.Certificate, crypto.Signer, error) {
 		return nil, nil, err
 	}
 
-	return cert, key, nil
+	return certs, key, nil
 }
 
-func loadCA() (*x509.Certificate, crypto.Signer, error) {
-	return LoadCerts("./certs/ca.pem", "./certs/ca.key")
+func loadCA() ([]*x509.Certificate, crypto.Signer, error) {
+	return LoadCertsChain("./certs/ca.pem", "./certs/ca.key")
 }
 
 func LoadCA(caPem, caKey []byte) (*x509.Certificate, crypto.Signer, error) {
+	chain, signer, err := LoadCAChain(caPem, caKey)
+	return chain[0], signer, err
+}
+
+func LoadCAChain(caPem, caKey []byte) ([]*x509.Certificate, crypto.Signer, error) {
 	key, err := cert.ParsePrivateKeyPEM(caKey)
 	if err != nil {
 		return nil, nil, err
@@ -70,15 +82,21 @@ func LoadCA(caPem, caKey []byte) (*x509.Certificate, crypto.Signer, error) {
 		return nil, nil, fmt.Errorf("key is not a crypto.Signer")
 	}
 
-	cert, err := ParseCertPEM(caPem)
+	certs, err := cert.ParseCertsPEM(caPem)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return cert, signer, nil
+	return certs, signer, nil
 }
 
+// Deprecated: Use LoadCertsChain instead as it supports intermediate CAs
 func LoadCerts(certFile, keyFile string) (*x509.Certificate, crypto.Signer, error) {
+	chain, signer, err := LoadCertsChain(certFile, keyFile)
+	return chain[0], signer, err
+}
+
+func LoadCertsChain(certFile, keyFile string) ([]*x509.Certificate, crypto.Signer, error) {
 	caPem, err := ioutil.ReadFile(certFile)
 	if err != nil {
 		return nil, nil, err
@@ -88,5 +106,5 @@ func LoadCerts(certFile, keyFile string) (*x509.Certificate, crypto.Signer, erro
 		return nil, nil, err
 	}
 
-	return LoadCA(caPem, caKey)
+	return LoadCAChain(caPem, caKey)
 }

--- a/listener.go
+++ b/listener.go
@@ -34,12 +34,12 @@ type SetFactory interface {
 	SetFactory(tls TLSFactory)
 }
 
-// Deprecated: Use NewListener2 instead as it supports intermediate CAs
+// Deprecated: Use NewListenerWithChain instead as it supports intermediate CAs
 func NewListener(l net.Listener, storage TLSStorage, caCert *x509.Certificate, caKey crypto.Signer, config Config) (net.Listener, http.Handler, error) {
-	return NewListener2(l, storage, []*x509.Certificate{caCert}, caKey, config)
+	return NewListenerWithChain(l, storage, []*x509.Certificate{caCert}, caKey, config)
 }
 
-func NewListener2(l net.Listener, storage TLSStorage, caCert []*x509.Certificate, caKey crypto.Signer, config Config) (net.Listener, http.Handler, error) {
+func NewListenerWithChain(l net.Listener, storage TLSStorage, caCert []*x509.Certificate, caKey crypto.Signer, config Config) (net.Listener, http.Handler, error) {
 	if config.CN == "" {
 		config.CN = "dynamic"
 	}

--- a/listener.go
+++ b/listener.go
@@ -34,7 +34,12 @@ type SetFactory interface {
 	SetFactory(tls TLSFactory)
 }
 
+// Deprecated: Use NewListener2 instead as it supports intermediate CAs
 func NewListener(l net.Listener, storage TLSStorage, caCert *x509.Certificate, caKey crypto.Signer, config Config) (net.Listener, http.Handler, error) {
+	return NewListener2(l, storage, []*x509.Certificate{caCert}, caKey, config)
+}
+
+func NewListener2(l net.Listener, storage TLSStorage, caCert []*x509.Certificate, caKey crypto.Signer, config Config) (net.Listener, http.Handler, error) {
 	if config.CN == "" {
 		config.CN = "dynamic"
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,8 @@ import (
 )
 
 type ListenOpts struct {
+	CAChain []*x509.Certificate
+	// Deprecated: Use CAChain instead
 	CA                *x509.Certificate
 	CAKey             crypto.Signer
 	Storage           dynamiclistener.TLSStorage
@@ -132,7 +134,7 @@ func getTLSListener(ctx context.Context, tcp net.Listener, handler http.Handler,
 		return nil, nil, err
 	}
 
-	listener, dynHandler, err := dynamiclistener.NewListener(tcp, storage, caCert, caKey, opts.TLSListenerConfig)
+	listener, dynHandler, err := dynamiclistener.NewListener2(tcp, storage, caCert, caKey, opts.TLSListenerConfig)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,13 +142,17 @@ func getTLSListener(ctx context.Context, tcp net.Listener, handler http.Handler,
 	return listener, wrapHandler(dynHandler, handler), nil
 }
 
-func getCA(opts ListenOpts) (*x509.Certificate, crypto.Signer, error) {
-	if opts.CA != nil && opts.CAKey != nil {
-		return opts.CA, opts.CAKey, nil
+func getCA(opts ListenOpts) ([]*x509.Certificate, crypto.Signer, error) {
+	if opts.CAKey != nil {
+		if opts.CAChain != nil {
+			return opts.CAChain, opts.CAKey, nil
+		} else if opts.CA != nil {
+			return []*x509.Certificate{opts.CA}, opts.CAKey, nil
+		}
 	}
 
 	if opts.Secrets == nil {
-		return factory.LoadOrGenCA()
+		return factory.LoadOrGenCAChain()
 	}
 
 	if opts.CAName == "" {
@@ -161,7 +167,7 @@ func getCA(opts ListenOpts) (*x509.Certificate, crypto.Signer, error) {
 		opts.CANamespace = "kube-system"
 	}
 
-	return kubernetes.LoadOrGenCA(opts.Secrets, opts.CANamespace, opts.CAName)
+	return kubernetes.LoadOrGenCAChain(opts.Secrets, opts.CANamespace, opts.CAName)
 }
 
 func newStorage(ctx context.Context, opts ListenOpts) dynamiclistener.TLSStorage {

--- a/storage/kubernetes/ca.go
+++ b/storage/kubernetes/ca.go
@@ -11,12 +11,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Deprecated: Use LoadOrGenCAChain instead as it supports intermediate CAs
 func LoadOrGenCA(secrets v1controller.SecretClient, namespace, name string) (*x509.Certificate, crypto.Signer, error) {
+	chain, signer, err := LoadOrGenCAChain(secrets, namespace, name)
+	return chain[0], signer, err
+}
+
+func LoadOrGenCAChain(secrets v1controller.SecretClient, namespace, name string) ([]*x509.Certificate, crypto.Signer, error) {
 	secret, err := getSecret(secrets, namespace, name)
 	if err != nil {
 		return nil, nil, err
 	}
-	return factory.LoadCA(secret.Data[v1.TLSCertKey], secret.Data[v1.TLSPrivateKeyKey])
+	return factory.LoadCAChain(secret.Data[v1.TLSCertKey], secret.Data[v1.TLSPrivateKeyKey])
 }
 
 func LoadOrGenClient(secrets v1controller.SecretClient, namespace, name, cn string, ca *x509.Certificate, key crypto.Signer) (*x509.Certificate, crypto.Signer, error) {

--- a/storage/kubernetes/ca.go
+++ b/storage/kubernetes/ca.go
@@ -14,6 +14,9 @@ import (
 // Deprecated: Use LoadOrGenCAChain instead as it supports intermediate CAs
 func LoadOrGenCA(secrets v1controller.SecretClient, namespace, name string) (*x509.Certificate, crypto.Signer, error) {
 	chain, signer, err := LoadOrGenCAChain(secrets, namespace, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	return chain[0], signer, err
 }
 


### PR DESCRIPTION
This PR tries to enable the dynamiclistener to hand out not only the first signing certificate it finds in the CA chain.

I stumbled on [this discussion](https://github.com/k3s-io/k3s/discussions/7596) while searching for the exact problem in k3s, where @brandond pointed to this repository.

Maybe it would be good to add tests but being not a go expert I struggle to comprehend the tests conducted on the listener.