### PR TITLE
Wrap Listener to also return dynamiclistener config

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -91,12 +91,6 @@ func NewListenerWithChain(l net.Listener, storage TLSStorage, caCert []*x509.Cer
 		setter.SetFactory(dynamicListener.factory)
 	}
 
-	if config.RegenerateCerts != nil && config.RegenerateCerts() {
-		if err := dynamicListener.RegenerateCerts(); err != nil {
-			return nil, err
-		}
-	}
-
 	tlsListener := tls.NewListener(dynamicListener.WrapExpiration(config.ExpirationDaysCheck), dynamicListener.tlsConfig)
 
 	return &Listener{
@@ -154,7 +148,6 @@ type Config struct {
 	MaxSANs               int
 	ExpirationDaysCheck   int
 	CloseConnOnCertChange bool
-	RegenerateCerts       func() bool
 	FilterCN              func(...string) []string
 }
 

--- a/listener.go
+++ b/listener.go
@@ -35,7 +35,7 @@ type SetFactory interface {
 }
 
 type Listener struct {
-	TlsListener net.Listener
+	TLSListener net.Listener
 	Handler     http.Handler
 	Listener    *listener
 }
@@ -100,7 +100,7 @@ func NewListenerWithChain(l net.Listener, storage TLSStorage, caCert []*x509.Cer
 	tlsListener := tls.NewListener(dynamicListener.WrapExpiration(config.ExpirationDaysCheck), dynamicListener.tlsConfig)
 
 	return &Listener{
-		TlsListener: tlsListener,
+		TLSListener: tlsListener,
 		Handler:     dynamicListener.cacheHandler(),
 		Listener:    dynamicListener,
 	}, nil

--- a/listener.go
+++ b/listener.go
@@ -34,18 +34,18 @@ type SetFactory interface {
 	SetFactory(tls TLSFactory)
 }
 
-type ListenerWrapper struct {
+type Listener struct {
 	TlsListener net.Listener
 	Handler     http.Handler
 	Listener    *listener
 }
 
 // Deprecated: Use NewListenerWithChain instead as it supports intermediate CAs
-func NewListener(l net.Listener, storage TLSStorage, caCert *x509.Certificate, caKey crypto.Signer, config Config) (*ListenerWrapper, error) {
+func NewListener(l net.Listener, storage TLSStorage, caCert *x509.Certificate, caKey crypto.Signer, config Config) (*Listener, error) {
 	return NewListenerWithChain(l, storage, []*x509.Certificate{caCert}, caKey, config)
 }
 
-func NewListenerWithChain(l net.Listener, storage TLSStorage, caCert []*x509.Certificate, caKey crypto.Signer, config Config) (*ListenerWrapper, error) {
+func NewListenerWithChain(l net.Listener, storage TLSStorage, caCert []*x509.Certificate, caKey crypto.Signer, config Config) (*Listener, error) {
 	if config.CN == "" {
 		config.CN = "dynamic"
 	}
@@ -99,7 +99,7 @@ func NewListenerWithChain(l net.Listener, storage TLSStorage, caCert []*x509.Cer
 
 	tlsListener := tls.NewListener(dynamicListener.WrapExpiration(config.ExpirationDaysCheck), dynamicListener.tlsConfig)
 
-	return &ListenerWrapper{
+	return &Listener{
 		TlsListener: tlsListener,
 		Handler:     dynamicListener.cacheHandler(),
 		Listener:    dynamicListener,

--- a/server/server.go
+++ b/server/server.go
@@ -149,7 +149,7 @@ func getTLSListener(ctx context.Context, tcp net.Listener, handler http.Handler,
 		return nil, nil, err
 	}
 
-	return listener.TlsListener, wrapHandler(listener.Handler, handler), nil
+	return listener.TLSListener, wrapHandler(listener.Handler, handler), nil
 }
 
 func getCA(opts ListenOpts) ([]*x509.Certificate, crypto.Signer, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -144,12 +144,12 @@ func getTLSListener(ctx context.Context, tcp net.Listener, handler http.Handler,
 		return nil, nil, err
 	}
 
-	wrapper, err := dynamiclistener.NewListenerWithChain(tcp, storage, caCert, caKey, opts.TLSListenerConfig)
+	listener, err := dynamiclistener.NewListenerWithChain(tcp, storage, caCert, caKey, opts.TLSListenerConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return wrapper.TlsListener, wrapHandler(wrapper.Handler, handler), nil
+	return listener.TlsListener, wrapHandler(listener.Handler, handler), nil
 }
 
 func getCA(opts ListenOpts) ([]*x509.Certificate, crypto.Signer, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -144,12 +144,12 @@ func getTLSListener(ctx context.Context, tcp net.Listener, handler http.Handler,
 		return nil, nil, err
 	}
 
-	listener, dynHandler, err := dynamiclistener.NewListenerWithChain(tcp, storage, caCert, caKey, opts.TLSListenerConfig)
+	wrapper, err := dynamiclistener.NewListenerWithChain(tcp, storage, caCert, caKey, opts.TLSListenerConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return listener, wrapHandler(dynHandler, handler), nil
+	return wrapper.TlsListener, wrapHandler(wrapper.Handler, handler), nil
 }
 
 func getCA(opts ListenOpts) ([]*x509.Certificate, crypto.Signer, error) {


### PR DESCRIPTION
### Proposed Changes

- Use a wrapper for easy access to the `listener` config

### Why

- K3s need to regenerate leaf certs with `hot reload` without the need for restart
- the main idea is to also return the config that was used for creating the listener, since the best way to regenerate/reload the dynamic listener cert `on demand` is to use the `listener` that was created in `NewListenerWithChain` initial setup.