### PR TITLE
Do not update memory storage with a nil secret

### DIFF
--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -47,6 +47,9 @@ func (m *memory) Update(secret *v1.Secret) error {
 }
 
 func isChanged(old, new *v1.Secret) bool {
+	if new == nil {
+		return false
+	}
 	if old == nil {
 		return true
 	}


### PR DESCRIPTION
Do not store a nil secret, fixes:
```
time="2025-09-12T21:03:40Z" level=info msg="Active TLS secret cattle-system/cattle-webhook-tls (ver=) (count -1): map[]"
```