### PR TITLE
Update VERSION.md for v0.9 main and new release/v0.8 branch

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -4,7 +4,8 @@ The current supported release lines are:
 
 | DynamicListener Branch | DynamicListener Minor version | Kubernetes Version Range | Wrangler Version |
 |------------------------|-------------------------------|--------------------------|------------------------------------------------|
-| main         | v0.8 | v1.27+        | v3 |
+| main         | v0.9 | v1.27+        | v3 |
+| release/v0.8 | v0.8 | v1.27 - v1.35 | v3 |
 | release/v0.7 | v0.7 | v1.27 - v1.34 | v3 |
 | release/v0.6 | v0.6 | v1.27 - v1.32 | v3 |
 | release/v0.5 | v0.5 | v1.26 - v1.30 | v3 |


### PR DESCRIPTION
Updates VERSION.md to reflect:
- `main` branch now tracks DynamicListener minor version **v0.9** (Kubernetes v1.27+)
- Adds new `release/v0.8` entry for DynamicListener minor version **v0.8** (Kubernetes v1.27 - v1.35)