### PR TITLE
[storage/file] Use atomic writes; treat empty file as nonexistent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rancher/dynamiclistener
 go 1.26.0
 
 require (
+	github.com/google/renameio/v2 v2.0.2
 	github.com/rancher/wrangler/v3 v3.7.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7O
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/renameio/v2 v2.0.2 h1:qKZs+tfn+arruZZhQ7TKC/ergJunuJicWS6gLDt/dGw=
+github.com/google/renameio/v2 v2.0.2/go.mod h1:OX+G6WHHpHq3NVj7cAOleLOwJfcQ1s3uUJQCrr78SWo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -1,9 +1,11 @@
 package file
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 
+	"github.com/google/renameio/v2"
 	"github.com/rancher/dynamiclistener"
 	v1 "k8s.io/api/core/v1"
 )
@@ -27,16 +29,23 @@ func (s *storage) Get() (*v1.Secret, error) {
 	}
 	defer f.Close()
 
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() == 0 {
+		return nil, nil
+	}
+
 	secret := v1.Secret{}
 	return &secret, json.NewDecoder(f).Decode(&secret)
 }
 
 func (s *storage) Update(secret *v1.Secret) error {
-	f, err := os.OpenFile(s.file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
+	b := &bytes.Buffer{}
+	if err := json.NewEncoder(b).Encode(secret); err != nil {
 		return err
 	}
-	defer f.Close()
 
-	return json.NewEncoder(f).Encode(secret)
+	return renameio.WriteFile(s.file, b.Bytes(), 0600, renameio.IgnoreUmask())
 }


### PR DESCRIPTION
Fixes issue where interrupted writes may leave the secret-backing file empty.

#### Linked Issues
* https://github.com/rancher/dynamiclistener/issues/311
* https://github.com/k3s-io/k3s/issues/14220