### PR TITLE
Fall back to os.WriteFile on windows

### DIFF
--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/google/renameio/v2"
 	"github.com/rancher/dynamiclistener"
 	v1 "k8s.io/api/core/v1"
 )
@@ -47,5 +46,5 @@ func (s *storage) Update(secret *v1.Secret) error {
 		return err
 	}
 
-	return renameio.WriteFile(s.file, b.Bytes(), 0600, renameio.IgnoreUmask())
+	return writeFile(s.file, b.Bytes(), 0600)
 }

--- a/storage/file/file_other.go
+++ b/storage/file/file_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package file
+
+import (
+	"os"
+
+	"github.com/google/renameio/v2"
+)
+
+func writeFile(name string, data []byte, perm os.FileMode) error {
+	return renameio.WriteFile(name, data, perm, renameio.IgnoreUmask())
+}

--- a/storage/file/file_windows.go
+++ b/storage/file/file_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package file
+
+import "os"
+
+// no atomic writes on windows, fall back to os.WriteFile
+// ref: https://github.com/google/renameio/blob/v2.0.2/README.md#windows-support
+var writeFile = os.WriteFile


### PR DESCRIPTION
As per https://github.com/google/renameio/blob/v2.0.2/README.md#windows-support is is not possible to do atomic file replacement on Windows, and renameio doesn't export any functions on Windows.