### PR TITLE
[storage/kubernetes] Guard queuedSecret with a mutex to fix data race

### DIFF
--- a/storage/kubernetes/controller.go
+++ b/storage/kubernetes/controller.go
@@ -35,7 +35,7 @@ type storage struct {
 
 	// mu guards queuedSecret, which is set from the Update caller and the
 	// secret watch goroutine, and read by the workqueue processor.
-	mu           sync.Mutex
+	mu           sync.RWMutex
 	queuedSecret *v1.Secret
 }
 
@@ -46,8 +46,8 @@ func (s *storage) setQueuedSecret(secret *v1.Secret) {
 }
 
 func (s *storage) getQueuedSecret() *v1.Secret {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.queuedSecret
 }
 

--- a/storage/kubernetes/controller.go
+++ b/storage/kubernetes/controller.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"maps"
+	"sync"
 	"time"
 
 	"github.com/rancher/dynamiclistener"
@@ -31,7 +32,23 @@ type storage struct {
 	secrets         v1controller.SecretController
 	tls             dynamiclistener.TLSFactory
 	queue           workqueue.TypedInterface[string]
-	queuedSecret    *v1.Secret
+
+	// mu guards queuedSecret, which is set from the Update caller and the
+	// secret watch goroutine, and read by the workqueue processor.
+	mu           sync.Mutex
+	queuedSecret *v1.Secret
+}
+
+func (s *storage) setQueuedSecret(secret *v1.Secret) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queuedSecret = secret
+}
+
+func (s *storage) getQueuedSecret() *v1.Secret {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.queuedSecret
 }
 
 func Load(ctx context.Context, secrets v1controller.SecretController, namespace, name string, backing dynamiclistener.TLSStorage) dynamiclistener.TLSStorage {
@@ -79,7 +96,7 @@ func (s *storage) Update(secret *v1.Secret) error {
 	// Asynchronously update the Kubernetes secret, as doing so inline may block the listener from
 	// accepting new connections if the apiserver becomes unavailable after the Secrets controller
 	// has been initialized.
-	s.queuedSecret = secret
+	s.setQueuedSecret(secret)
 	s.queue.Add(s.name)
 	return nil
 }
@@ -120,7 +137,7 @@ func (s *storage) init(ctx context.Context, secrets v1controller.SecretControlle
 				return
 			case ev := <-watch.ResultChan():
 				if secret, ok := ev.Object.(*v1.Secret); ok {
-					s.queuedSecret = secret
+					s.setQueuedSecret(secret)
 					s.queue.Add(secret.Name)
 				}
 			}
@@ -128,7 +145,8 @@ func (s *storage) init(ctx context.Context, secrets v1controller.SecretControlle
 	}()
 
 	// enqueue initial sync of the backing secret
-	s.queuedSecret, _ = s.Get()
+	secret, _ := s.Get()
+	s.setQueuedSecret(secret)
 	s.queue.Add(s.name)
 }
 
@@ -242,9 +260,12 @@ func isConflictOrAlreadyExists(err error) bool {
 // queued secret with the Kubernetes secret.  Only after successfully
 // updating the Kubernetes secret will the backing storage be updated.
 func (s *storage) update() (err error) {
+	// Snapshot the queued secret once, so a concurrent Update or watch event
+	// cannot swap it out from under the retry loop.
+	queuedSecret := s.getQueuedSecret()
 	var newSecret *v1.Secret
 	if err := retry.OnError(retry.DefaultRetry, isConflictOrAlreadyExists, func() error {
-		newSecret, err = s.saveInK8s(s.queuedSecret)
+		newSecret, err = s.saveInK8s(queuedSecret)
 		return err
 	}); err != nil {
 		return err

--- a/storage/kubernetes/controller_test.go
+++ b/storage/kubernetes/controller_test.go
@@ -1,0 +1,58 @@
+package kubernetes
+
+import (
+	"sync"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// memoryStorage is a minimal TLSStorage backing for tests.
+type memoryStorage struct {
+	mu     sync.Mutex
+	secret *v1.Secret
+}
+
+func (m *memoryStorage) Get() (*v1.Secret, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.secret, nil
+}
+
+func (m *memoryStorage) Update(secret *v1.Secret) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secret = secret
+	return nil
+}
+
+// TestUpdateQueuedSecretRace runs Update (which sets queuedSecret) concurrently
+// with update (which reads it) to ensure access to queuedSecret is
+// synchronized. secrets is left nil so saveInK8s short-circuits and no
+// apiserver is needed. Run with -race: without the mutex this reports a data
+// race on queuedSecret, with it the two paths are serialized.
+func TestUpdateQueuedSecretRace(t *testing.T) {
+	s := &storage{
+		name:    "test",
+		storage: &memoryStorage{},
+		queue:   workqueue.NewTyped[string](),
+	}
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = s.Update(&v1.Secret{})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = s.update()
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
`storage.queuedSecret` was written from three goroutines (the `Update` caller,
the secret watch, and the initial sync in `init`) and read by the workqueue
processor's `update`, with no synchronization, so certificate updates could
race (#247).

This adds a mutex to the `storage` struct and routes every `queuedSecret`
access through `setQueuedSecret` / `getQueuedSecret`. `update` snapshots the
queued secret once before the conflict-retry loop, so the lock is never held
across an apiserver call and a concurrent write cannot swap the secret
mid-retry.

Scope: this fixes the data race only. The logical lost-update race (a watch
event overwriting a freshly generated cert) noted in #247 is left for a
follow-up.

Validation (local):
- Added `storage/kubernetes/controller_test.go` reproducing the race.
  `go test -race ./storage/kubernetes/` reports the race on the current code
  (controller.go:82 vs :247) and passes with the fix.
- `go vet ./...`, `go build ./...`, `go test -race -cover ./...` all pass.

Fixes #247
