### PR TITLE
Adopt self-contained per-branch renovate rules, trim unsupported branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,11 +4,9 @@
   ],
   "baseBranchPatterns": [
     "main",
+    "release/v0.8",
     "release/v0.7",
-    "release/v0.6",
-    "release/v0.5",
-    "release/v0.4",
-    "release/v0.3"
+    "release/v0.6"
   ],
   "prHourlyLimit": 2,
   "enabledManagers": [
@@ -18,10 +16,56 @@
   ],
   "packageRules": [
     {
+      "description": "release/v0.8 supports Kubernetes v1.27 - v1.35 (see VERSION.md); cap k8s.io/* to the matching client-go line",
+      "matchManagers": ["gomod"],
+      "matchBaseBranches": ["release/v0.8"],
+      "matchPackageNames": [
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "!k8s.io/klog/v2",
+        "!k8s.io/klog/v2/**",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.36",
+      "groupName": "Kubernetes dependencies"
+    },
+    {
+      "description": "release/v0.7 supports Kubernetes v1.27 - v1.34 (see VERSION.md); cap k8s.io/* to the matching client-go line",
+      "matchManagers": ["gomod"],
+      "matchBaseBranches": ["release/v0.7"],
+      "matchPackageNames": [
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "!k8s.io/klog/v2",
+        "!k8s.io/klog/v2/**",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.35",
+      "groupName": "Kubernetes dependencies"
+    },
+    {
+      "description": "release/v0.6 supports Kubernetes v1.27 - v1.32 (see VERSION.md); cap k8s.io/* to the matching client-go line",
+      "matchManagers": ["gomod"],
+      "matchBaseBranches": ["release/v0.6"],
+      "matchPackageNames": [
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "!k8s.io/klog/v2",
+        "!k8s.io/klog/v2/**",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.33",
+      "groupName": "Kubernetes dependencies"
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
-        "/k8s.io/*/",
-        "/sigs.k8s.io/*/",
         "/github.com/prometheus/*/",
         "/github.com/rancher/wrangler/*/"
       ]

--- a/VERSION.md
+++ b/VERSION.md
@@ -8,6 +8,3 @@ The current supported release lines are:
 | release/v0.8 | v0.8 | v1.27 - v1.35 | v3 |
 | release/v0.7 | v0.7 | v1.27 - v1.34 | v3 |
 | release/v0.6 | v0.6 | v1.27 - v1.32 | v3 |
-| release/v0.5 | v0.5 | v1.26 - v1.30 | v3 |
-| release/v0.4 | v0.4 | v1.25 - v1.28 | v2 |
-| release/v0.3 | v0.3 | v1.23 - v1.27 | v2 |


### PR DESCRIPTION
Part of rancher/rancher#56562.

**Reworked per review feedback** — no longer ties dynamiclistener's Renovate config to `rancher/renovate-config`'s per-rancher-line presets (`rancher-2.11.json` etc.), since this repo is also consumed by k3s and other non-rancher projects. `.github/renovate.json` now carries local rules keyed to dynamiclistener's own declared Kubernetes support range (`VERSION.md`), not a rancher release line:

- `release/v0.8` (Kubernetes v1.27 - v1.35) -> `k8s.io/*` capped at `<0.36`
- `release/v0.7` (Kubernetes v1.27 - v1.34) -> `k8s.io/*` capped at `<0.35`
- `release/v0.6` (Kubernetes v1.27 - v1.32) -> `k8s.io/*` capped at `<0.33`
- `main` (v1.27+, open-ended) -> no ceiling

`k8s.io/utils`, `k8s.io/kube-openapi`, and `k8s.io/klog/v2` are excluded from the ceiling groups since they don't follow the client-go `v0.<minor>` versioning scheme the ceiling assumes.

The top-level `rancher/renovate-config#release` extend stays — that's generic automerge/stability policy, not tied to a rancher release line, so it doesn't reintroduce the k3s-compatibility concern. It already provides the 7-day stability window and automerge for patch/minor + security updates. Kept alongside it: the existing guards against major bumps and Go/`golang.org/x/tools` minor bumps on release branches, and the digest-freeze rule that keeps the pinned preset ref from drifting on release branches.

`release/v0.5`, `release/v0.4`, and `release/v0.3` have no active consumer, so they're dropped from `baseBranchPatterns` entirely, and the corresponding rows are trimmed from `VERSION.md` to match.
