### PR TITLE
[main] Fix flaky server log tests

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,12 +6,24 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	assertPkg "github.com/stretchr/testify/assert"
+)
+
+const (
+	// logWaitTimeout bounds how long a test waits for an asynchronously
+	// written server log to show up, and logPollInterval how often it looks.
+	logWaitTimeout  = 10 * time.Second
+	logPollInterval = 10 * time.Millisecond
+
+	// logSettleDelay is how long a test waits before asserting that a server
+	// log was never written.
+	logSettleDelay = 500 * time.Millisecond
 )
 
 type alwaysPanicHandler struct {
@@ -87,15 +99,20 @@ func TestHttpServerLogWithLogrus(t *testing.T) {
 	var buf bytes.Buffer
 	var mutex sync.Mutex
 	safeWriter := newSafeWriter(&buf, &mutex)
-	err := doRequest(safeWriter, message, logrus.ErrorLevel)
+	err := doRequest(safeWriter, 9012, message, logrus.ErrorLevel)
 	assert.Nil(err)
 
-	mutex.Lock()
-	s := buf.String()
-	assert.Greater(len(s), 0)
-	assert.Contains(s, msg)
-	assert.Contains(s, "panic serving 127.0.0.1")
-	mutex.Unlock()
+	// ListenAndServe hands http.Server an ErrorLog backed by
+	// logrus.Logger.WriterLevel, which is an *io.PipeWriter drained by a
+	// background goroutine. The server's panic log therefore reaches the
+	// logrus output some time after the client request has failed, so poll
+	// for it instead of reading the buffer once.
+	assert.Eventually(func() bool {
+		mutex.Lock()
+		defer mutex.Unlock()
+		s := buf.String()
+		return strings.Contains(s, msg) && strings.Contains(s, "panic serving 127.0.0.1")
+	}, logWaitTimeout, logPollInterval, "server panic was never logged")
 }
 
 func TestHttpNoServerLogsWithLogrus(t *testing.T) {
@@ -105,8 +122,12 @@ func TestHttpNoServerLogsWithLogrus(t *testing.T) {
 	var buf bytes.Buffer
 	var mutex sync.Mutex
 	safeWriter := newSafeWriter(&buf, &mutex)
-	err := doRequest(safeWriter, message, logrus.DebugLevel)
+	err := doRequest(safeWriter, 9013, message, logrus.DebugLevel)
 	assert.Nil(err)
+
+	// Nothing to poll for here: give the asynchronous writer a chance to
+	// emit before asserting that it never does.
+	time.Sleep(logSettleDelay)
 
 	mutex.Lock()
 	s := buf.String()
@@ -116,11 +137,10 @@ func TestHttpNoServerLogsWithLogrus(t *testing.T) {
 	mutex.Unlock()
 }
 
-func doRequest(safeWriter *safeWriter, message string, logLevel logrus.Level) error {
+func doRequest(safeWriter *safeWriter, httpPort int, message string, logLevel logrus.Level) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	host := "127.0.0.1"
-	httpPort := 9012
 	httpsPort := 0
 	msg := fmt.Sprintf("panicking context: %s", message)
 	handler := alwaysPanicHandler{msg: msg}


### PR DESCRIPTION
## Problem

The tests in `server/server_test.go` are flaky. They fail on PRs that touch nothing but dependencies — most recently the Renovate `golang.org/x/crypto` bump for `release/v0.8` (#335), whose diff is `go.mod`/`go.sum` only.

There are two independent races, with different symptoms.

### 1. The server's panic log is written asynchronously

`ListenAndServe` builds the `http.Server`'s `ErrorLog` from `logrus.Logger.WriterLevel(...)`, which returns an `*io.PipeWriter` drained by a background goroutine that re-emits each line through logrus. When the handler panics, `net/http` writes `panic serving 127.0.0.1:...` into that pipe and closes the connection. The pipe write blocks until the scanner goroutine reads it, but the scanner still has to call through to logrus afterwards, and the client's request has already failed by then. `TestHttpServerLogWithLogrus` read the buffer exactly once, immediately, so under contention it observed only the earlier `Listening on ...` line:

```
server_test.go:96:
    Error: "time=\"...\" level=info msg=\"Listening on 127.0.0.1:9012\"\n" does not contain "panicking context: debug-level writer"
server_test.go:97:
    Error: "time=\"...\" level=info msg=\"Listening on 127.0.0.1:9012\"\n" does not contain "panic serving 127.0.0.1"
--- FAIL: TestHttpServerLogWithLogrus (0.02s)
```


### 2. Both tests bind port 9012

The listener is closed by `go func() { <-ctx.Done(); httpServer.Shutdown(...) }()`, which is asynchronous, so `TestHttpNoServerLogsWithLogrus` can try to bind before `TestHttpServerLogWithLogrus`'s listener is released. That path ends in `logrus.Fatalf("http server failed: %v", err)` — `os.Exit(1)`.

This one is invisible. `doRequest` has already pointed `logrus.StandardLogger()` at the test's own buffer, so the fatal message is swallowed and the package just dies mid-test with no failing assertion:

```
=== RUN   TestHttpServerLogWithLogrus
--- PASS: TestHttpServerLogWithLogrus (0.01s)
=== RUN   TestHttpNoServerLogsWithLogrus
FAIL	github.com/rancher/dynamiclistener/server	0.051s
```

This is the mode that reproduces most readily, and is the likelier cause of any past "CI failed but nothing looks wrong" reruns.

## Fix

Test-only. No production code and no exported API is touched.

- Poll for the expected log lines with `assert.Eventually` (10s timeout, 10ms interval) instead of reading the buffer once.
- Give `TestHttpNoServerLogsWithLogrus` its own port (9013) via a new `httpPort` parameter on the `doRequest` helper.
- In the negative test, wait a short settle delay before asserting the message was never logged, since there is nothing to poll for.

## Verification

`GOMAXPROCS=1 CGO_ENABLED=1 go test -race -cover -count=1 -cpu=1 ./server/`, run in a loop:

| | failures |
|---|---|
| `main` before | 40/220 (18%) |
| this branch | 0/250 |

